### PR TITLE
feat: support for loading placeholders

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "svelte": "^3.48.0",
     "svelte-check": "^2.7.1",
     "svelte-preprocess": "^4.10.6",
+    "svelte-content-placeholder": "file:../../EstebanBorai/svelte-content-placeholder",
     "tailwindcss": "^3.0.22",
     "tslib": "^2.3.1",
     "typescript": "~4.5.4",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "svelte": "^3.48.0",
     "svelte-check": "^2.7.1",
     "svelte-preprocess": "^4.10.6",
-    "svelte-content-placeholder": "file:../../EstebanBorai/svelte-content-placeholder",
+    "svelte-content-placeholder": "^0.1.0-beta-2",
     "tailwindcss": "^3.0.22",
     "tslib": "^2.3.1",
     "typescript": "~4.5.4",

--- a/src/lib/components/Feed.svelte
+++ b/src/lib/components/Feed.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
   import SmileyXEyes from 'phosphor-svelte/lib/SmileyXEyes';
-
   import Post from '$lib/components/Post.svelte';
   import classNames from 'classnames';
+  import Placeholder from 'svelte-content-placeholder';
+
+  import Card from './Card.svelte';
 
   import type { OperationResultStore } from '@urql/svelte/dist/types/common';
 
@@ -16,7 +18,16 @@
 
 <ul class={className}>
   {#if $posts.fetching}
-    Please wait...
+    <li class="pt-4">
+      <Card class="h-[122px]">
+        <Placeholder width="100%">
+          <rect x="2" y="2" rx="8" ry="8" width="63" height="62" />
+          <rect x="75" y="3" rx="8" ry="8" width="149" height="22" />
+          <rect x="77" y="41" rx="8" ry="8" width="110" height="19" />
+          <rect x="2" y="72" rx="8" ry="8" width="394" height="19" />
+        </Placeholder>
+      </Card>
+    </li>
   {:else}
     {#each $posts.data.feed.feed.edges.map(({ node }) => node) as post}
       <li>


### PR DESCRIPTION
Now the feed loads with a nice placeholder.
In the future the blink can be improved/fixed by using
some subscription to the query.

---

To merge this PR first merge: #16.

## Demo

https://user-images.githubusercontent.com/34756077/173501537-0af2a738-6f78-4bee-89b9-4176ff2f29ac.mov

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
